### PR TITLE
Fixed issue-16: RestoreModified method

### DIFF
--- a/Frends.FTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.FTP.DownloadFiles/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.2] - 2022-08-25
+### Fixed
+- Fixed RestoreModified method to use the whole path of the destination file and not just the name.
+- Fixed logging of successful transfer to use the name of the file and not reference of FileItem class.
+
 ## [1.0.1] - 2022-06-15
 ### Fixed
 - Added DisplayFormat annotation to the Connection ClientCertificatePath input field.

--- a/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles/Definitions/SingleFileTransfer.cs
@@ -364,8 +364,6 @@ internal class SingleFileTransfer
             case SourceOperation.Move:
             case SourceOperation.Rename:
                 return true;
-            case SourceOperation.Delete:
-            case SourceOperation.Nothing:
             default:
                 return false;
         }

--- a/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles/Definitions/SingleFileTransfer.cs
@@ -199,7 +199,7 @@ internal class SingleFileTransfer
     /// </summary>
     private void RestoreModified()
     {
-        File.SetLastWriteTime(DestinationFileNameWithMacrosExpanded, SourceFile.Modified);
+        File.SetLastWriteTime(GetDestinationFilePath(DestinationFileNameWithMacrosExpanded), SourceFile.Modified);
     }
 
     private void ExecuteSourceOperation()

--- a/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles.csproj
+++ b/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles.csproj
@@ -11,7 +11,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Description>Task for downloading files from FTP(S) servers.</Description>
   </PropertyGroup>
 

--- a/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles/Logging/FtpLogger.cs
+++ b/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles/Logging/FtpLogger.cs
@@ -74,7 +74,7 @@ internal class FtpLogger : IFtpLogger
         {
             var fileTransferInfoForSuccess = CreateFileTransferInfo(TransferResult.Success, transfer, context);
             _fileTransfers.Add(fileTransferInfoForSuccess);
-            _log.Information("File transfer succeeded: " + transfer.SourceFile);
+            _log.Information("File transfer succeeded: " + transfer.SourceFile.Name);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
- Fixed RestoreModified method to use the whole path of the destination file and not just the name.
- Fixed logging of successful transfer to use the name of the file and not reference of FileItem class.