### PR TITLE
FTP.DownloadFiles - Bug fix

### DIFF
--- a/Frends.FTP.DownloadFiles/CHANGELOG.md
+++ b/Frends.FTP.DownloadFiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.3] - 2024-01-30
+### Fixed
+- Fixed bug when using wildcard filemask and no source files were found.
+
 ## [1.1.2] - 2024-01-16
 ### Improved
 - Improved Operations log by adding more logging steps.

--- a/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles.Tests/DownloadFilesTests.cs
+++ b/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles.Tests/DownloadFilesTests.cs
@@ -263,7 +263,6 @@ namespace Frends.FTP.DownloadFiles.Tests
             };
 
             var ex = Assert.Throws<Exception>(() => FTP.DownloadFiles(source, destination, connection, options, new Info(), new CancellationToken()));
-            Console.WriteLine(ex.Message);
             Assert.IsTrue(ex.Message.Contains("1 Errors: No source files found from directory"));
 
             FtpHelper.DeleteDirectoryOnFTP(sourceDir);

--- a/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles.Tests/DownloadFilesTests.cs
+++ b/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles.Tests/DownloadFilesTests.cs
@@ -241,7 +241,7 @@ namespace Frends.FTP.DownloadFiles.Tests
         {
             var sourceDir = "ftp";
             FtpHelper.CreateDirectoryOnFTP(sourceDir);
-            
+
             var source = new Source { Directory = sourceDir, FileName = "*", Operation = SourceOperation.Nothing, NotFoundAction = SourceNotFoundAction.Error };
             var destination = new Destination { Directory = LocalDirFullPath, Action = DestinationAction.Error };
             var connection = new Connection

--- a/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles.Tests/DownloadFilesTests.cs
+++ b/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles.Tests/DownloadFilesTests.cs
@@ -235,5 +235,34 @@ namespace Frends.FTP.DownloadFiles.Tests
             Assert.IsTrue(result.Success, result.UserResultMessage);
             Assert.AreEqual(1, result.SuccessfulTransferCount);
         }
+
+        [Test]
+        public void DownloadFTP_NoSourceFiles()
+        {
+            var sourceDir = "ftp";
+            var source = new Source { Directory = sourceDir, FileName = "*", Operation = SourceOperation.Nothing, NotFoundAction = SourceNotFoundAction.Error };
+            var destination = new Destination { Directory = LocalDirFullPath, Action = DestinationAction.Error };
+            var connection = new Connection
+            {
+                Address = FtpHelper.FtpHost,
+                UserName = FtpHelper.FtpUsername,
+                Password = FtpHelper.FtpPassword,
+                Port = FtpHelper.FtpPort
+            };
+
+            var options = new Options
+            {
+                CreateDestinationDirectories = true,
+                OperationLog = true,
+                PreserveLastModified = true,
+                RenameDestinationFileDuringTransfer = true,
+                RenameSourceFileBeforeTransfer = true,
+                ThrowErrorOnFail = true
+            };
+
+            var ex = Assert.Throws<Exception>(() => FTP.DownloadFiles(source, destination, connection, options, new Info(), new CancellationToken()));
+            Console.WriteLine(ex.Message);
+            Assert.IsTrue(ex.Message.Contains("1 Errors: No source files found from directory"));
+        }
     }
 }

--- a/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles.Tests/DownloadFilesTests.cs
+++ b/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles.Tests/DownloadFilesTests.cs
@@ -240,6 +240,8 @@ namespace Frends.FTP.DownloadFiles.Tests
         public void DownloadFTP_NoSourceFiles()
         {
             var sourceDir = "ftp";
+            FtpHelper.CreateDirectoryOnFTP(sourceDir);
+            
             var source = new Source { Directory = sourceDir, FileName = "*", Operation = SourceOperation.Nothing, NotFoundAction = SourceNotFoundAction.Error };
             var destination = new Destination { Directory = LocalDirFullPath, Action = DestinationAction.Error };
             var connection = new Connection
@@ -263,6 +265,8 @@ namespace Frends.FTP.DownloadFiles.Tests
             var ex = Assert.Throws<Exception>(() => FTP.DownloadFiles(source, destination, connection, options, new Info(), new CancellationToken()));
             Console.WriteLine(ex.Message);
             Assert.IsTrue(ex.Message.Contains("1 Errors: No source files found from directory"));
+
+            FtpHelper.DeleteDirectoryOnFTP(sourceDir);
         }
     }
 }

--- a/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles/Definitions/FileTransporter.cs
+++ b/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles/Definitions/FileTransporter.cs
@@ -242,8 +242,9 @@ internal class FileTransporter
 
         list.AddRange(ftpFiles
             .Where(e => e.Type != FtpFileSystemObjectType.Directory
-            || e.Type != FtpFileSystemObjectType.Link
-            || !Util.FileMatchesMask(e.Name, _batchContext.Source.FileName)).Select(f => new FileItem(f)));
+            && e.Type != FtpFileSystemObjectType.Link
+            && Util.FileMatchesMask(e.Name, _batchContext.Source.FileName))
+            .Select(f => new FileItem(f)));
 
         return new Tuple<List<FileItem>, bool>(list, true);
     }

--- a/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles.csproj
+++ b/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles/Frends.FTP.DownloadFiles.csproj
@@ -11,7 +11,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <Description>Task for downloading files from FTP(S) servers.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
#43 

## [1.1.3] - 2024-01-30
### Fixed
- Fixed bug when using wildcard filemask and no source files were found.