### PR TITLE
FTP.UploadFiles checksum and retry

### DIFF
--- a/Frends.FTP.UploadFiles/CHANGELOG.md
+++ b/Frends.FTP.UploadFiles/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.2.0]
+### Added
+- Added check for file checksum and size.
+- Added retry attempts parameter to retry the transfer if checksum or file size differs.
+
 ## [1.1.1] - 2024-01-18
 ### Added
 - Added setup for FtpClient.ReadTimeout, FtpClient.DataConnectionConnectTimeout and FtpClient.DataConnectionReadTimeout which were all defaulting to 15 seconds.

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/DestinationOperationTests.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/DestinationOperationTests.cs
@@ -2,6 +2,7 @@
 using Frends.FTP.UploadFiles.TaskConfiguration;
 using Frends.FTP.UploadFiles.TaskResult;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
 using System.Threading;
 
 namespace Frends.FTP.UploadFiles.Tests;
@@ -22,7 +23,7 @@ public class DestinationActionTests : UploadFilesTestBase
         Assert.IsTrue(result1.Success, result1.UserResultMessage);
         Assert.IsTrue(result2.Success, result2.UserResultMessage);
         Assert.AreEqual(1, result2.SuccessfulTransferCount);
-        Assert.AreEqual("mycontentmycontent", Helpers.GetFileFromFtp(nameof(DestinationAction_Append_NoRenameInTransfer), "file1.txt"));
+        Assert.AreEqual("mycontentmycontent", File.ReadAllText(Helpers.GetFileFromFtp(nameof(DestinationAction_Append_NoRenameInTransfer), "file1.txt")));
     }
 
     [TestMethod]
@@ -38,7 +39,7 @@ public class DestinationActionTests : UploadFilesTestBase
         Assert.IsTrue(result1.Success, result1.UserResultMessage);
         Assert.IsTrue(result2.Success, result2.UserResultMessage);
         Assert.AreEqual(1, result2.SuccessfulTransferCount);
-        Assert.AreEqual("mycontentmycontent", Helpers.GetFileFromFtp(nameof(DestinationAction_Append_WithRenameInTransfer), "file1.txt"));
+        Assert.AreEqual("mycontentmycontent", File.ReadAllText(Helpers.GetFileFromFtp(nameof(DestinationAction_Append_WithRenameInTransfer), "file1.txt")));
     }
 
     private Result CallUploadFiles(

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/Frends.FTP.UploadFiles.Tests.csproj
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/Frends.FTP.UploadFiles.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net471</TargetFramework>
+		<TargetFrameworks>net471;net6.0</TargetFrameworks>
 		<LangVersion>Latest</LangVersion>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/Frends.FTP.UploadFiles.Tests.csproj
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/Frends.FTP.UploadFiles.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net471;net6.0</TargetFrameworks>
+		<TargetFramework>net6.0</TargetFramework>
 		<LangVersion>Latest</LangVersion>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/Frends.FTP.UploadFiles.Tests.csproj
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/Frends.FTP.UploadFiles.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-
+		<TargetFramework>net471</TargetFramework>
+		<LangVersion>Latest</LangVersion>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
@@ -11,6 +11,8 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
+		<PackageReference Include="nunit" Version="3.12.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
@@ -19,6 +21,10 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Frends.FTP.UploadFiles\Frends.FTP.UploadFiles.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="DotNetZip" Version="1.16.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/UploadFilesTests.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/UploadFilesTests.cs
@@ -715,7 +715,7 @@ public class UploadFilesTests
         var errors = 0;
         var success = 0;
 
-        for (var i = 0; i < 25; i++)
+        for (var i = 0; i < 10; i++)
         {
             try
             {
@@ -735,7 +735,7 @@ public class UploadFilesTests
 
         Console.WriteLine($"Errors: {errors}\nSuccessful: {success}");
 
-        Assert.AreEqual(25, success);
+        Assert.AreEqual(10, success);
         Assert.AreEqual(0, errors);
     }
 
@@ -760,7 +760,7 @@ public class UploadFilesTests
 
         _connection.VerifyOption = VerifyOptions.Throw;
 
-        for (int i = 0; i < 25; i++)
+        for (int i = 0; i < 10; i++)
         {
             try
             {

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/UploadFilesTests.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/UploadFilesTests.cs
@@ -117,8 +117,8 @@ public class UploadFilesTests
         connection.CertificateHashStringSHA1 = "incorrect";
 
         // Test and assert
-        var ex = Assert.Throws<AuthenticationException>(() => FTP.UploadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
-        Assert.IsTrue(ex.Message.Contains("The remote certificate is invalid according to the validation procedure."));
+        var ex = Assert.Throws<AggregateException>(() => FTP.UploadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+        Assert.IsTrue(ex.Message.Contains("The remote certificate was rejected by the provided RemoteCertificateValidationCallback."));
     }
 
     [Test]
@@ -419,7 +419,6 @@ public class UploadFilesTests
                 Assert.AreEqual(0, result.TransferredFileNames.Count(), $"Port: {port}");
                 Assert.AreEqual(0, result.TransferredFilePaths.Count(), $"Port: {port}");
                 Assert.IsTrue(result.UserResultMessage.Contains("Unable to establish the socket: No such host is known."), $"Port: {port}");
-                Assert.IsTrue(result.OperationsLog.Count < 4, $"Port: {port}");
             }
             else
             {
@@ -430,7 +429,6 @@ public class UploadFilesTests
                 Assert.AreEqual(1, result.TransferredFileNames.Count(), $"Port: {port}");
                 Assert.AreEqual(1, result.TransferredFilePaths.Count(), $"Port: {port}");
                 Assert.IsTrue(result.UserResultMessage.Contains("files transferred"), $"Port: {port}");
-                Assert.IsTrue(result.OperationsLog.Count < 4, $"Port: {port}");
             }
 
             CleanUp();
@@ -680,17 +678,17 @@ public class UploadFilesTests
             ClientCertificateThumbprint = ""
         };
 
-        var ex = Assert.Throws<AuthenticationException>(() =>
+        var ex = Assert.Throws<AggregateException>(() =>
         {
             FTP.UploadFiles(_source, _destination, connection, new Options(), new Info(),
                 default);
 
         });
 
-        Assert.IsTrue(ex.Message.Contains("The remote certificate is invalid according to the validation procedure."));
+        Assert.IsTrue(ex.Message.Contains("The remote certificate was rejected by the provided RemoteCertificateValidationCallback."));
     }
 
-    [Test]
+    //[Test]
     public void UploadFTP_TestVerifyOptionsRetry()
     {
         var path = Helpers.CreateLargeDummyZipFiles(_tempDir, 10);
@@ -739,7 +737,7 @@ public class UploadFilesTests
         Assert.AreEqual(0, errors);
     }
 
-    [Test]
+    //[Test]
     public void UploadFTP_TestVerifyOptionsThrow()
     {
         var path = Helpers.CreateLargeDummyZipFiles(_tempDir, 10);

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/UploadFilesTests.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/UploadFilesTests.cs
@@ -688,7 +688,7 @@ public class UploadFilesTests
         Assert.IsTrue(ex.Message.Contains("The remote certificate was rejected by the provided RemoteCertificateValidationCallback."));
     }
 
-    //[Test]
+    [Test]
     public void UploadFTP_TestVerifyOptionsRetry()
     {
         var path = Helpers.CreateLargeDummyZipFiles(_tempDir, 10);
@@ -737,7 +737,7 @@ public class UploadFilesTests
         Assert.AreEqual(0, errors);
     }
 
-    //[Test]
+    [Test]
     public void UploadFTP_TestVerifyOptionsThrow()
     {
         var path = Helpers.CreateLargeDummyZipFiles(_tempDir, 10);

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/UploadFilesTests.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/UploadFilesTests.cs
@@ -1,8 +1,9 @@
 using FluentFTP;
 using Frends.FTP.UploadFiles.Enums;
 using Frends.FTP.UploadFiles.TaskConfiguration;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Authentication;
@@ -10,7 +11,7 @@ using System.Threading;
 
 namespace Frends.FTP.UploadFiles.Tests;
 
-[TestClass]
+[TestFixture]
 public class UploadFilesTests
 {
     private string _tempDir;
@@ -22,7 +23,7 @@ public class UploadFilesTests
     private Options _options = new();
     private Info _info = new();
 
-    [TestInitialize]
+    [SetUp]
     public void SetUp()
     {
         _tempDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "../../../tempFiles");
@@ -52,7 +53,7 @@ public class UploadFilesTests
             KeepConnectionAliveInterval = default,
             ConnectionTimeout = 60,
             Encoding = default,
-            BufferSize = default,
+            BufferSize = 4096,
             UseFTPS = false,
             SslMode = default,
             CertificateHashStringSHA1 = "D911262984DE9CC32A3518A1094CD24249EA5C49",
@@ -60,6 +61,8 @@ public class UploadFilesTests
             ValidateAnyCertificate = default,
             ClientCertificatePath = default,
             SecureDataChannel = false,
+            VerifyOption = default,
+            RetryAttempts = 0,
         };
 
         _destination = new()
@@ -72,11 +75,11 @@ public class UploadFilesTests
         _options = new()
         {
             CreateDestinationDirectories = true,
-            OperationLog = default,
-            PreserveLastModified = default,
-            RenameDestinationFileDuringTransfer = default,
-            RenameSourceFileBeforeTransfer = default,
-            ThrowErrorOnFail = default,
+            OperationLog = true,
+            PreserveLastModified = true,
+            RenameDestinationFileDuringTransfer = true,
+            RenameSourceFileBeforeTransfer = true,
+            ThrowErrorOnFail = true,
         };
 
         _info = new()
@@ -88,7 +91,7 @@ public class UploadFilesTests
         };
     }
 
-    [TestCleanup]
+    [TearDown]
     public void CleanUp()
     {
         if (Directory.Exists(_tempDir))
@@ -105,7 +108,7 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_IncorrectFingerprint()
     {
         var connection = _connection;
@@ -114,12 +117,11 @@ public class UploadFilesTests
         connection.CertificateHashStringSHA1 = "incorrect";
 
         // Test and assert
-        var ex = Assert.ThrowsException<AggregateException>(() => FTP.UploadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
-        Assert.AreEqual(1, ex.InnerExceptions.Count);
-        Assert.AreEqual(typeof(AuthenticationException), ex.InnerExceptions[0].GetType());
+        var ex = Assert.Throws<AuthenticationException>(() => FTP.UploadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+        Assert.IsTrue(ex.Message.Contains("The remote certificate is invalid according to the validation procedure."));
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_IncorrectAuth()
     {
         var connectionA = _connection;
@@ -134,20 +136,20 @@ public class UploadFilesTests
         var connectionD = _connection;
         connectionD.UserName = null;
 
-        var ex1 = Assert.ThrowsException<NullReferenceException>(() => FTP.UploadFiles(_source, _destination, connectionA, _options, _info, new CancellationToken()));
+        var ex1 = Assert.Throws<NullReferenceException>(() => FTP.UploadFiles(_source, _destination, connectionA, _options, _info, new CancellationToken()));
         Assert.AreEqual(typeof(NullReferenceException), ex1.GetType());
 
-        var ex2 = Assert.ThrowsException<NullReferenceException>(() => FTP.UploadFiles(_source, _destination, connectionB, _options, _info, new CancellationToken()));
+        var ex2 = Assert.Throws<NullReferenceException>(() => FTP.UploadFiles(_source, _destination, connectionB, _options, _info, new CancellationToken()));
         Assert.AreEqual(typeof(NullReferenceException), ex2.GetType());
 
-        var ex3 = Assert.ThrowsException<NullReferenceException>(() => FTP.UploadFiles(_source, _destination, connectionC, _options, _info, new CancellationToken()));
+        var ex3 = Assert.Throws<NullReferenceException>(() => FTP.UploadFiles(_source, _destination, connectionC, _options, _info, new CancellationToken()));
         Assert.AreEqual(typeof(NullReferenceException), ex3.GetType());
 
-        var ex4 = Assert.ThrowsException<NullReferenceException>(() => FTP.UploadFiles(_source, _destination, connectionD, _options, _info, new CancellationToken()));
+        var ex4 = Assert.Throws<NullReferenceException>(() => FTP.UploadFiles(_source, _destination, connectionD, _options, _info, new CancellationToken()));
         Assert.AreEqual(typeof(NullReferenceException), ex4.GetType());
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTP_UploadFile()
     {
         var result = FTP.UploadFiles(_source, _destination, _connection, _options, _info, new CancellationToken());
@@ -155,7 +157,7 @@ public class UploadFilesTests
         Assert.AreEqual(1, result.SuccessfulTransferCount);
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_DestinationActions()
     {
         var destinationActions = new[] { DestinationAction.Error, DestinationAction.Overwrite, DestinationAction.Append };
@@ -180,10 +182,12 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_FtpMode()
     {
         var ftpModes = new[] { FtpMode.Active, FtpMode.Passive };
+
+        _options.ThrowErrorOnFail = false;
 
         foreach (var ftpMode in ftpModes)
         {
@@ -218,7 +222,7 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_FtpsSslModes()
     {
         var ftpsSslModes = new[] { FtpsSslMode.None, FtpsSslMode.Explicit, FtpsSslMode.Auto };
@@ -244,7 +248,7 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_SecureDataChannel()
     {
         var boo = new[] { true, false };
@@ -269,7 +273,7 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_FtpTransportTypes()
     {
         var ftpTransportTypes = new[] { FtpTransportType.Binary, FtpTransportType.Ascii };
@@ -294,13 +298,14 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_NotFoundActions()
     {
         var notFoundActions = new[] { SourceNotFoundAction.Error, SourceNotFoundAction.Ignore, SourceNotFoundAction.Info };
 
         foreach (var notFoundAction in notFoundActions)
         {
+            _options.ThrowErrorOnFail = false;
             var source = _source;
             source.NotFoundAction = notFoundAction;
             source.FileName = "";
@@ -335,7 +340,7 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_SourceOperations()
     {
         var sourceOperations = new[] { SourceOperation.Move, SourceOperation.Delete, SourceOperation.Rename, SourceOperation.Nothing };
@@ -360,7 +365,7 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_FileEncodings()
     {
         var fileEncodings = new[] { "UTF-8", "ASCII", "foobar123", string.Empty };
@@ -372,7 +377,7 @@ public class UploadFilesTests
 
             if (connection.Encoding.Equals("foobar123"))
             {
-                var ex = Assert.ThrowsException<ArgumentException>(() => FTP.UploadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
+                var ex = Assert.Throws<ArgumentException>(() => FTP.UploadFiles(_source, _destination, connection, _options, _info, new CancellationToken()));
                 Assert.IsTrue(ex.Message.Contains("is not a supported encoding name"), $"FileEncoding: {fileEncoding}");
             }
             else
@@ -393,13 +398,14 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_Port()
     {
         var ports = new[] { 0, 21, 210 };
 
         foreach (var port in ports)
         {
+            _options.ThrowErrorOnFail = false;
             var connection = _connection;
             connection.Port = port;
 
@@ -432,13 +438,14 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_KeepConnectionAliveInterval()
     {
-        var intervals = new[] { 0, 1, 100 };
+        var intervals = new[] { 1, 100, 0 };
 
         foreach (var interval in intervals)
         {
+            _options.ThrowErrorOnFail = true;
             var connection = _connection;
             connection.KeepConnectionAliveInterval = interval;
 
@@ -450,14 +457,13 @@ public class UploadFilesTests
             Assert.AreEqual(1, result.TransferredFileNames.Count(), $"Interval: {interval}");
             Assert.AreEqual(1, result.TransferredFilePaths.Count(), $"Interval: {interval}");
             Assert.IsTrue(result.UserResultMessage.Contains("files transferred"), $"Interval: {interval}");
-            Assert.IsTrue(result.OperationsLog.Count < 4, $"Interval: {interval}");
 
             CleanUp();
             SetUp();
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_ConnectionTimeout()
     {
         var timeouts = new[] { 10, 15, 50, 100 };
@@ -482,7 +488,7 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_BufferSize()
     {
         var sizes = new[] { 1, 100, 1000, 10000 };
@@ -507,7 +513,7 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_ValidateAnyCertificate()
     {
         var boo = new[] { true, false };
@@ -532,7 +538,7 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_FileNameAfterTransfer_Missing()
     {
         var source = _source;
@@ -550,10 +556,12 @@ public class UploadFilesTests
         Assert.IsTrue(result.OperationsLog.Count < 4);
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_DirectoryToMoveAfterTransfer_Missing()
     {
         var sourceOperations = new[] { SourceOperation.Move, SourceOperation.Delete, SourceOperation.Rename, SourceOperation.Nothing };
+
+        _options.ThrowErrorOnFail = false;
 
         foreach (var sourceOperation in sourceOperations)
         {
@@ -590,7 +598,7 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_ThrowErrorOnFail()
     {
         var source = _source;
@@ -599,11 +607,11 @@ public class UploadFilesTests
         var options = _options;
         options.ThrowErrorOnFail = true;
 
-        var ex = Assert.ThrowsException<Exception>(() => FTP.UploadFiles(source, _destination, _connection, options, _info, new CancellationToken()));
+        var ex = Assert.Throws<Exception>(() => FTP.UploadFiles(source, _destination, _connection, options, _info, new CancellationToken()));
         Assert.AreEqual(typeof(Exception), ex.GetType());
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_PreserveLastModified()
     {
         var boo = new[] { true, false };
@@ -628,7 +636,7 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_OperationLog()
     {
         var boo = new[] { true, false };
@@ -653,7 +661,7 @@ public class UploadFilesTests
         }
     }
 
-    [TestMethod]
+    [Test]
     public void UploadFTPS_CurrentUserHasNoCertificates()
     {
         var connection = new Connection
@@ -672,14 +680,101 @@ public class UploadFilesTests
             ClientCertificateThumbprint = ""
         };
 
-        var ex = Assert.ThrowsException<AggregateException>(() =>
+        var ex = Assert.Throws<AuthenticationException>(() =>
         {
             FTP.UploadFiles(_source, _destination, connection, new Options(), new Info(),
                 default);
 
         });
 
-        Assert.AreEqual(1, ex.InnerExceptions.Count);
-        Assert.AreEqual(typeof(AuthenticationException), ex.InnerExceptions[0].GetType());
+        Assert.IsTrue(ex.Message.Contains("The remote certificate is invalid according to the validation procedure."));
+    }
+
+    [Test]
+    public void UploadFTP_TestVerifyOptionsRetry()
+    {
+        var path = Helpers.CreateLargeDummyZipFiles(_tempDir, 10);
+
+        var source = new Source
+        {
+            FilePaths = new string[] { path },
+            Operation = SourceOperation.Nothing,
+            NotFoundAction = SourceNotFoundAction.Error
+        };
+
+        var destination = new Destination
+        {
+            Directory = _tempDir,
+            FileName = "test.zip",
+            Action = DestinationAction.Overwrite
+        };
+
+        _connection.VerifyOption = VerifyOptions.Retry;
+        _connection.RetryAttempts = 5;
+
+        var errors = 0;
+        var success = 0;
+
+        for (var i = 0; i < 25; i++)
+        {
+            try
+            {
+                var result = FTP.UploadFiles(source, destination, _connection, _options, _info, default);
+                var sourcePath = Path.Combine(destination.Directory, destination.FileName);
+
+                var testfile = Helpers.GetFileFromFtp(Path.GetDirectoryName(sourcePath), Path.GetFileName(sourcePath));
+                Assert.IsTrue(Helpers.ExtractLargeZipFile(testfile, _tempDir));
+                success++;
+            }
+            catch (Exception ex)
+            {
+                errors++;
+                Console.WriteLine(ex.Message);
+            }
+        }
+
+        Console.WriteLine($"Errors: {errors}\nSuccessful: {success}");
+
+        Assert.AreEqual(25, success);
+        Assert.AreEqual(0, errors);
+    }
+
+    [Test]
+    public void UploadFTP_TestVerifyOptionsThrow()
+    {
+        var path = Helpers.CreateLargeDummyZipFiles(_tempDir, 10);
+
+        var source = new Source
+        {
+            FilePaths = new string[] { path },
+            Operation = SourceOperation.Nothing,
+            NotFoundAction = SourceNotFoundAction.Error
+        };
+
+        var destination = new Destination
+        {
+            Directory = _tempDir,
+            FileName = "test.zip",
+            Action = DestinationAction.Overwrite
+        };
+
+        _connection.VerifyOption = VerifyOptions.Throw;
+
+        for (int i = 0; i < 25; i++)
+        {
+            try
+            {
+                var result = FTP.UploadFiles(source, destination, _connection, _options, _info, default);
+                Assert.IsTrue(result.Success);
+                var sourcePath = Path.Combine(destination.Directory, destination.FileName);
+                var testfile = Helpers.GetFileFromFtp(Path.GetDirectoryName(sourcePath), Path.GetFileName(sourcePath));
+                Assert.IsTrue(Helpers.ExtractLargeZipFile(testfile, _tempDir));
+            }
+            catch (Exception ex)
+            {
+                Assert.IsTrue(ex.Message.Contains("Transferred file size or Checksum was different from the source file."));
+                break;
+            }
+        }
     }
 }

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Definitions/FileTransporter.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Definitions/FileTransporter.cs
@@ -197,7 +197,8 @@ namespace Frends.FTP.UploadFiles.Definitions
                 client.DataConnectionEncryption = connect.SecureDataChannel;
             }
 
-            client.NoopInterval = connect.KeepConnectionAliveInterval;
+            if (connect.KeepConnectionAliveInterval > 0)
+                client.NoopInterval = connect.KeepConnectionAliveInterval;
 
             if (!string.IsNullOrWhiteSpace(connect.Encoding)) client.Encoding = Encoding.GetEncoding(connect.Encoding);
 
@@ -206,6 +207,9 @@ namespace Frends.FTP.UploadFiles.Definitions
             client.ReadTimeout = connect.ConnectionTimeout * 1000;
             client.DataConnectionConnectTimeout = connect.ConnectionTimeout * 1000;
             client.DataConnectionReadTimeout = connect.ConnectionTimeout * 1000;
+
+            if (connect.VerifyOption == VerifyOptions.Retry)
+                client.RetryAttempts = connect.RetryAttempts > 0 ? connect.RetryAttempts : 0;
 
             client.LocalFileBufferSize = connect.BufferSize;
 
@@ -313,7 +317,7 @@ namespace Frends.FTP.UploadFiles.Definitions
         {
             var success = singleResults.All(x => x.Success);
             var actionSkipped = success && singleResults.All(x => x.ActionSkipped);
-            var userResultMessage = FileTransporter.GetUserResultMessage(singleResults.ToList());
+            var userResultMessage = GetUserResultMessage(singleResults.ToList());
 
             var transferErrors = singleResults.Where(r => !r.Success).GroupBy(r => r.TransferredFile ?? "--unknown--")
                     .ToDictionary(rg => rg.Key, rg => (IList<string>)rg.SelectMany(r => r.ErrorMessages).ToList());

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Definitions/SingleFileTransfer.cs
@@ -89,7 +89,7 @@ namespace Frends.FTP.UploadFiles.Definitions
             {
                 CleanUpFiles();
             }
-            
+
             return _result;
         }
 

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Enums/TransferState.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Enums/TransferState.cs
@@ -14,6 +14,8 @@
         RenameDestinationFile,
         CleanUpFiles,
         CheckIfDestinationFileExists,
-        DestinationFileExists
+        DestinationFileExists,
+        Checksum,
+        RestoreModified
     }
 }

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Enums/VerifyOptions.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Enums/VerifyOptions.cs
@@ -1,0 +1,25 @@
+﻿namespace Frends.FTP.UploadFiles.Enums
+{
+    /// <summary>
+    /// Options for verifying the file after transfer.
+    /// </summary>
+    public enum VerifyOptions
+    {
+        /// <summary>
+        /// No verification of the file is performed
+        /// </summary>
+        None,
+        /// <summary>
+        /// The checksum of the file is verified, if supported by the server. If the checksum
+        /// comparison fails then the Task will retry the download/upload a specified amount of times
+        /// before giving up. If the checksum is invalid on the last attempt the Task will delete the file and throw an exception.
+        /// (See Frends.FTP.UploadFiles.Connection.RetryAttempts)
+        /// </summary>
+        Retry,
+        /// <summary>
+        /// The checksum of the file is verified, if supported by the server. If the checksum
+        /// comparison fails then an exception will be thrown.
+        /// </summary>
+        Throw
+    }
+}

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/FTP.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/FTP.cs
@@ -137,7 +137,6 @@ namespace Frends.FTP.UploadFiles
                 var fileTransporter = new FileTransporter(logger, batchContext, executionId);
                 var result = fileTransporter.Run(cancellationToken);
 
-                var test = options.ThrowErrorOnFail;
                 if (options.ThrowErrorOnFail && !result.Success)
                     throw new Exception($"SFTP transfer failed: {result.UserResultMessage}. " +
                                         $"Latest operations: \n{GetLogLines(transferSink.GetBufferedLogMessages())}");

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/FTP.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/FTP.cs
@@ -137,6 +137,7 @@ namespace Frends.FTP.UploadFiles
                 var fileTransporter = new FileTransporter(logger, batchContext, executionId);
                 var result = fileTransporter.Run(cancellationToken);
 
+                var test = options.ThrowErrorOnFail;
                 if (options.ThrowErrorOnFail && !result.Success)
                     throw new Exception($"SFTP transfer failed: {result.UserResultMessage}. " +
                                         $"Latest operations: \n{GetLogLines(transferSink.GetBufferedLogMessages())}");

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.csproj
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.csproj
@@ -10,7 +10,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
     <Description>Task for uploading files to FTP(S) servers.</Description>
   </PropertyGroup>
 

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/TaskConfiguration/Connection.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/TaskConfiguration/Connection.cs
@@ -116,9 +116,9 @@ namespace Frends.FTP.UploadFiles.TaskConfiguration
 
         /// <summary>
         /// If set, Task will do checksum check for the transferred file after the transfer. If the checksum fails Task can be configured to retry the transfer.
-        /// If Checksumn fails the transferred file is removed and Task will throw an error, because the content is most likely corrupted.
+        /// If Checksum fails the transferred file is removed and Task will throw an error, because the content is most likely corrupted.
         /// </summary>
-        /// <example>false</example>
+        /// <example>VerifyOptions.None</example>
         [DefaultValue(VerifyOptions.None)]
         public VerifyOptions VerifyOption { get; set; }
 
@@ -128,7 +128,7 @@ namespace Frends.FTP.UploadFiles.TaskConfiguration
         /// </summary>
         /// <example>5</example>
         [UIHint(nameof(VerifyOptions), "", VerifyOptions.Retry)]
-        [DefaultValue(0)]
+        [DefaultValue(3)]
         public int RetryAttempts { get; set; }
 
         #region FTPS settings

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/TaskConfiguration/Connection.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/TaskConfiguration/Connection.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using Frends.FTP.UploadFiles.Enums;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace Frends.FTP.UploadFiles.TaskConfiguration
@@ -112,6 +113,23 @@ namespace Frends.FTP.UploadFiles.TaskConfiguration
         /// <example>4096</example>
         [DefaultValue(4096)]
         public int BufferSize { get; set; }
+
+        /// <summary>
+        /// If set, Task will do checksum check for the transferred file after the transfer. If the checksum fails Task can be configured to retry the transfer.
+        /// If Checksumn fails the transferred file is removed and Task will throw an error, because the content is most likely corrupted.
+        /// </summary>
+        /// <example>false</example>
+        [DefaultValue(VerifyOptions.None)]
+        public VerifyOptions VerifyOption { get; set; }
+
+        /// <summary>
+        /// Value for how many retries the Task will do while uploading the file.
+        /// Task will check the checksum of the file and based on that retries if necessary.
+        /// </summary>
+        /// <example>5</example>
+        [UIHint(nameof(VerifyOptions), "", VerifyOptions.Retry)]
+        [DefaultValue(0)]
+        public int RetryAttempts { get; set; }
 
         #region FTPS settings
 


### PR DESCRIPTION
#49 

## [1.2.0]
### Added
- Added check for file checksum and size.
- Added retry attempts parameter to retry the transfer if checksum or file size differs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for Frends.FTP.UploadFiles Version 1.2.0

- **New Features**
	- Added file checksum and size verification during uploads.
	- Introduced retry attempts parameter for file transfers in case of discrepancies.
	- New verification options for file integrity checks after transfer.
  
- **Improvements**
	- Enhanced error handling and connection management for file transfers.
	- Updated testing framework to NUnit for improved test structure and readability.
	- Added functionality for creating and extracting large zip files.

- **Documentation**
	- Changelog updated to reflect new version and features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->