### PR TITLE
FTP.UploadFiles - Fixed issue with Task not throwing when retry fails

### DIFF
--- a/Frends.FTP.UploadFiles/CHANGELOG.md
+++ b/Frends.FTP.UploadFiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.0] - 2024-12-11
+### Fixed
+- Fixed issue with Task not throwing even when retry failed.
+
 ## [1.2.0]
 ### Added
 - Added check for file checksum and size.

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/UploadFilesTests.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/UploadFilesTests.cs
@@ -2,12 +2,9 @@ using FluentFTP;
 using Frends.FTP.UploadFiles.Enums;
 using Frends.FTP.UploadFiles.TaskConfiguration;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Authentication;
 using System.Threading;
 
 namespace Frends.FTP.UploadFiles.Tests;

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/UploadFilesTests.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.Tests/UploadFilesTests.cs
@@ -2,6 +2,7 @@ using FluentFTP;
 using Frends.FTP.UploadFiles.Enums;
 using Frends.FTP.UploadFiles.TaskConfiguration;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -719,7 +720,6 @@ public class UploadFilesTests
             {
                 var result = FTP.UploadFiles(source, destination, _connection, _options, _info, default);
                 var sourcePath = Path.Combine(destination.Directory, destination.FileName);
-
                 var testfile = Helpers.GetFileFromFtp(Path.GetDirectoryName(sourcePath), Path.GetFileName(sourcePath));
                 Assert.IsTrue(Helpers.ExtractLargeZipFile(testfile, _tempDir));
                 success++;

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Definitions/RenamingPolicy.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Definitions/RenamingPolicy.cs
@@ -111,7 +111,7 @@ namespace Frends.FTP.UploadFiles.Definitions
 
         private static char[] GetInvalidChars()
         {
-            List<char> invalidCharacters = new List<char>(Path.GetInvalidFileNameChars());
+            List<char> invalidCharacters = new(Path.GetInvalidFileNameChars());
             invalidCharacters.Remove('/'); // remove the forward slash, as it is supported
             invalidCharacters.Remove(':'); // also the colon is supported
             return invalidCharacters.ToArray();

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Definitions/SingleFileTransfer.cs
@@ -188,10 +188,11 @@ namespace Frends.FTP.UploadFiles.Definitions
                     _client.DeleteFile(_destinationFileDuringTransfer);
                     throw new ArgumentException($"Transferred file size or Checksum was different from the source file. File {Path.GetFileName(_sourceFileDuringTransfer)} was most likely corrupted during transfer.");
                 }
-                catch (Exception ex)
+                catch (FtpCommandException ex)
                 {
                     // Log the exception and decide whether to proceed or rethrow
                     _logger.NotifyError(_batchContext, $"Failed to delete corrupted file '{_destinationFileDuringTransfer}': {ex.Message}", ex);
+                    throw ex;
                 }
             }
 

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Definitions/SingleFileTransfer.cs
@@ -1,5 +1,4 @@
 ﻿using FluentFTP;
-using FluentFTP.Helpers;
 using Frends.FTP.UploadFiles.Enums;
 using Frends.FTP.UploadFiles.Logging;
 using System;
@@ -392,16 +391,11 @@ namespace Frends.FTP.UploadFiles.Definitions
                 return true;
             }
 
-            switch (_batchContext.Source.Operation)
+            return _batchContext.Source.Operation switch
             {
-                case SourceOperation.Move:
-                case SourceOperation.Rename:
-                    return true;
-                case SourceOperation.Delete:
-                case SourceOperation.Nothing:
-                default:
-                    return false;
-            }
+                SourceOperation.Move or SourceOperation.Rename => true,
+                _ => false,
+            };
         }
 
         private void Trace(TransferState state, string format, params object[] args)
@@ -413,14 +407,12 @@ namespace Frends.FTP.UploadFiles.Definitions
         /// <summary>
         /// Exception class for more specific Exception name.
         /// </summary>
-        public class DestinationFileExistsException : Exception
+        /// <remarks>
+        /// Exception message.
+        /// </remarks>
+        /// <param name="fileName"></param>
+        public class DestinationFileExistsException(string fileName) : Exception($"Unable to transfer file. Destination file already exists: {fileName}")
         {
-            /// <summary>
-            /// Exception message.
-            /// </summary>
-            /// <param name="fileName"></param>
-            public DestinationFileExistsException(string fileName)
-                : base($"Unable to transfer file. Destination file already exists: {fileName}") { }
         }
     }
 }

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Definitions/SingleFileTransfer.cs
@@ -407,12 +407,14 @@ namespace Frends.FTP.UploadFiles.Definitions
         /// <summary>
         /// Exception class for more specific Exception name.
         /// </summary>
-        /// <remarks>
-        /// Exception message.
-        /// </remarks>
-        /// <param name="fileName"></param>
-        public class DestinationFileExistsException(string fileName) : Exception($"Unable to transfer file. Destination file already exists: {fileName}")
+        public class DestinationFileExistsException : Exception
         {
+            /// <summary>
+            /// Exception message.
+            /// </summary>
+            /// <param name="fileName"></param>
+            public DestinationFileExistsException(string fileName)
+                : base($"Unable to transfer file. Destination file already exists: {fileName}") { }
         }
     }
 }

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Definitions/SingleFileTransfer.cs
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Definitions/SingleFileTransfer.cs
@@ -191,7 +191,7 @@ namespace Frends.FTP.UploadFiles.Definitions
                 {
                     // Log the exception and decide whether to proceed or rethrow
                     _logger.NotifyError(_batchContext, $"Failed to delete corrupted file '{_destinationFileDuringTransfer}': {ex.Message}", ex);
-                    throw ex;
+                    throw;
                 }
             }
 

--- a/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.csproj
+++ b/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles/Frends.FTP.UploadFiles.csproj
@@ -10,7 +10,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Description>Task for uploading files to FTP(S) servers.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
#49 

## [1.3.0] - 2024-12-11
### Fixed
- Fixed issue with Task not throwing even when retry failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Version 1.3.0 released with enhanced error handling for FTP uploads.
	- Added detailed logging and retry mechanisms for file transfer failures.

- **Bug Fixes**
	- Resolved an issue where errors were not thrown on failed retry attempts.

- **Tests**
	- Expanded test coverage for various FTP upload scenarios, including error handling related to SSL certificate validation and authentication failures.

- **Documentation**
	- Updated changelog to reflect changes and enhancements in version 1.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->